### PR TITLE
Re-use Project Namespace for Project Herbie-compatible module

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+INTRODUCTION
+------------
+
+This module allows for core's path-generated breadcrumbs to be modified
+according to UNL web guidelines.
+
+  * The root breadcrumb for all sites is "Nebraska", and it links 
+    to https://www.unl.edu. This is not configurable.
+  * For non-flagship sites, there is an optional Site Root Breadcrumb
+    Title, which prints immediately after the "Nebraska" root item.
+    This is configurable.
+  * The menu link title (unlinked) is printed as the final breadcrumb item.
+    In the event the page is not in a menu, its page title is
+    printed instead. This is not configurable.
+
+The default breadcrumb for an "Example" page might be as follows:
+
+[Home](https://example.com) > [Parent Item](https://example.com/parent)
+
+The UNL Breadcrumb for this same page would be as follows:
+
+[Nebraska](https://www.unl.edu) > [[Site Root Breadcrumb Title]](https://example.com/) > [Parent Item](https://example.com/parent) > Example Page
+
+## Interstitial Breadcrumbs
+Interstitial breadcrumbs allow an organizational hierarchy back to www.unl.edu
+in the event this site is not a child of www.unl.edu. For example, if the
+Center for Excellent Examples, which is part of the College of Examples, has
+its own website, then the default breadcrumbs would be "Nebraska > Center for
+Excellent Examples" instead of "Nebraska > College of Examples > Center for
+Excellent Examples". Interstitial breadcrumbs allow missing breadcrumbs to be
+added for a complete hierarchy. Interstitial breadcrumbs are inserted between
+"Nebraska" and the site root breadcrumb.
+
+INSTALLATION
+------------
+
+Install as you would normally install a contributed Drupal module. Visit:
+[https://www.drupal.org/docs/8/extending-drupal-8/installing-drupal-8-modules](https://www.drupal.org/docs/8/extending-drupal-8/installing-drupal-8-modules)
+for further information.
+
+CONFIGURATION
+-------------
+
+All configuration is global for a given Drupal site.
+
+  * Navigate to the UNL Breadcrumbs configuration page
+    (/admin/config/user-interface/unl-breadcrumbs)
+
+MAINTAINERS
+-----------
+
+Current maintainers:
+  * Chris Burge - https://www.drupal.org/u/chris-burge

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "unlcms/unl_breadcrumbs",
+  "description": "UNL breadcrumb implementation",
+  "type": "drupal-module",
+  "license": "GPL-2.0+",
+  "authors": [
+    {
+      "name": "Chris Burge",
+      "homepage": "https://www.drupal.org/u/chris-burge",
+      "role": "Maintainer"
+    }
+  ]
+}

--- a/config/schema/unl_breadcrumbs.schema.yml
+++ b/config/schema/unl_breadcrumbs.schema.yml
@@ -1,0 +1,19 @@
+unl_breadcrumbs.settings:
+  type: config_object
+  mapping:
+    site_root_breadcrumb_title:
+      label: Site Root Breadcrumb Title
+      type: string
+    interstitial_breadcrumbs:
+      label: Interstitial Breadcrumbs
+      type: sequence
+      sequence:
+        label: Interstitial Item
+        type: mapping
+        mapping:
+          title:
+            label: Title
+            type: string
+          url:
+            label: URL
+            type: uri

--- a/config/schema/unl_breadcrumbs.schema.yml
+++ b/config/schema/unl_breadcrumbs.schema.yml
@@ -4,7 +4,7 @@ unl_breadcrumbs.settings:
     site_root_breadcrumb_title:
       label: Site Root Breadcrumb Title
       type: string
-    site_root_breadcrumb_title_use_site_title:
+    site_root_breadcrumb_title_use_site_name:
       label: Use Site Title as Site Root Breadcrumb Title
       type: boolean
     interstitial_breadcrumbs:

--- a/config/schema/unl_breadcrumbs.schema.yml
+++ b/config/schema/unl_breadcrumbs.schema.yml
@@ -4,6 +4,9 @@ unl_breadcrumbs.settings:
     site_root_breadcrumb_title:
       label: Site Root Breadcrumb Title
       type: string
+    site_root_breadcrumb_title_use_site_title:
+      label: Use Site Title as Site Root Breadcrumb Title
+      type: boolean
     interstitial_breadcrumbs:
       label: Interstitial Breadcrumbs
       type: sequence

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -50,15 +50,15 @@ class SettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('site_root_breadcrumb_title'),
       '#states' => [
         'disabled' => [
-          ':input[name="site_root_breadcrumb_title_use_site_title"]' => ['checked' => TRUE],
+          ':input[name="site_root_breadcrumb_title_use_site_name"]' => ['checked' => TRUE],
         ],
       ],
     ];
-    $form['site_root_breadcrumb_title_use_site_title'] = [
+    $form['site_root_breadcrumb_title_use_site_name'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Use Site Title as Site Root Breadcrumb Title'),
-      '#description' => $this->t('If checked, the Site Title will be used instead of a custom title.'),
-      '#default_value' => $config->get('site_root_breadcrumb_title_use_site_title'),
+      '#title' => $this->t('Use Site Name for Site Root Breadcrumb Title'),
+      '#description' => $this->t('If checked, the Site Name will be used instead of a custom title.'),
+      '#default_value' => $config->get('site_root_breadcrumb_title_use_site_name'),
     ];
 
     $form['interstitial_wrapper'] = [
@@ -216,7 +216,7 @@ class SettingsForm extends ConfigFormBase {
     $this->configFactory->getEditable(static::SETTINGS)
       // Set the submitted configuration setting.
       ->set('site_root_breadcrumb_title', $form_state->getValue('site_root_breadcrumb_title'))
-      ->set('site_root_breadcrumb_title_use_site_title', $form_state->getValue('site_root_breadcrumb_title_use_site_title'))
+      ->set('site_root_breadcrumb_title_use_site_name', $form_state->getValue('site_root_breadcrumb_title_use_site_name'))
       ->set('interstitial_breadcrumbs', $interstitial)
       ->save();
 

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Drupal\unl_breadcrumbs\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Configure unl_breadcrumbs settings for this site.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'unl_breadcrumbs.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'unl_breadcrumbs_admin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      static::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(static::SETTINGS);
+
+    $form['markup'] = [
+      '#markup' => $this->t('When UNL Breadcrumbs is enabled, breadcrumbs must follow a prescribed pattern: "Nebraska > [Site Root Breadcrumb Title] > [Parent Items] > [Page Title]".<br>Configurable options can be managed below:'),
+    ];
+
+    $form['site_root_breadcrumb_title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Site Root Breadcrumb Title'),
+      '#description' => $this->t('The title used for this site in breadcrumbs. E.g. "Nebraska > [Site Root Breadcrumb Title] > [Page Title]". In the instance of the flagship site, this setting will be empty.'),
+      '#default_value' => $config->get('site_root_breadcrumb_title'),
+    ];
+
+    $form['interstitial_wrapper'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Interstitial Breadcrumbs'),
+    ];
+    $form['interstitial_wrapper']['markup'] = [
+      '#markup' => $this->t('Interstitial breadcrumbs allow an organizational hierarchy back to www.unl.edu in the event this site is not a child of www.unl.edu. For example, if the Center for Excellent Examples, which is part of the College of Examples, has its own website, then the default breadcrumbs would be "Nebraska > Center for Excellent Examples" instead of "Nebraska > College of Examples > Center for Excellent Examples". Interstitial breadcrumbs allow missing breadcrumbs to be added for a complete hierarchy. Interstitial breadcrumbs are inserted between "Nebraska" and the site root breadcrumb.'),
+    ];
+    $form['interstitial_wrapper']['interstitial'] = [
+      '#type' => 'table',
+      '#prefix' => '<div id="interstitial-wrapper">',
+      '#suffix' => '</div>',
+      '#header' => [
+        '',
+        $this->t('Title'),
+        $this->t('URL'),
+        $this->t('Weight'),
+        $this->t('Actions'),
+      ],
+      '#tabledrag' => [
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'interstitial-order-weight',
+        ],
+      ],
+    ];
+
+    if ($form_state->isRebuilding()) {
+      $interstitial_config = $form_state->getValue('interstitial');
+    }
+    else {
+      $interstitial_config = $config->get('interstitial_breadcrumbs');
+    }
+
+    foreach ($interstitial_config as $delta => $item) {
+      // TableDrag: Weight column element.
+      $form['interstitial_wrapper']['interstitial'][$delta]['#attributes']['class'][] = 'draggable';
+      $form['interstitial_wrapper']['interstitial'][$delta]['#weight'] = isset($delta) ? $delta : 0;
+      $form['interstitial_wrapper']['interstitial'][$delta]['drag'] = [
+        '#markup' => '',
+      ];
+      $form['interstitial_wrapper']['interstitial'][$delta]['title'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Title'),
+        '#title_display' => 'invisible',
+        '#description' => $this->t('*Required field'),
+        '#size' => NULL,
+        '#default_value' => ($item['title']) ? $item['title'] : '',
+        '#required' => TRUE,
+      ];
+      $form['interstitial_wrapper']['interstitial'][$delta]['url'] = [
+        '#type' => 'url',
+        '#title' => $this->t('URL'),
+        '#title_display' => 'invisible',
+        '#description' => $this->t('*Required field'),
+        '#size' => NULL,
+        '#default_value' => ($item['url']) ? $item['url'] : '',
+        '#required' => TRUE,
+      ];
+      $form['interstitial_wrapper']['interstitial'][$delta]['weight'] = [
+        '#type' => 'weight',
+        '#title' => $this->t('Weight for interstitial item @delta', ['@delta' => $delta]),
+        '#title_display' => 'invisible',
+        '#attributes' => ['class' => ['interstitial-order-weight']],
+        '#default_value' => isset($delta) ? $delta : 0,
+      ];
+      $form['interstitial_wrapper']['interstitial'][$delta]['delete'] = [
+        '#type' => 'submit',
+        '#title' => $this->t('Remove'),
+        '#name' => 'delete_' . $delta,
+        '#value' => 'Remove',
+        '#submit' => ['::ajaxSubmit'],
+        '#ajax' => [
+          'callback' => '::addMoreSet',
+          'wrapper' => 'interstitial-wrapper',
+        ],
+      ];
+    }
+
+    $form['interstitial_wrapper']['add'] = [
+      '#type' => 'submit',
+      '#title' => $this->t('Add interstitial breadcrumb'),
+      '#value' => $this->t('Add more'),
+      '#submit' => ['::ajaxSubmit'],
+      '#ajax' => [
+        'callback' => '::addMoreSet',
+        'wrapper' => 'interstitial-wrapper',
+      ],
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Callback function to add a row to interstitial table.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   The interstitial portion of the $form array.
+   */
+  public function addMoreSet(array &$form, FormStateInterface $form_state) {
+    return $form['interstitial_wrapper']['interstitial'];
+  }
+
+  /**
+   * Callback submit function to add/remove rows to interstitial table.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function ajaxSubmit(array &$form, FormStateInterface $form_state) {
+    $items = $form_state->getValue('interstitial');
+    if (empty($items)) {
+      $items = [];
+    }
+    $parents = $form_state->getTriggeringElement()['#parents'];
+    if (isset($parents[0]) && $parents[0] == 'add') {
+      $items[] = [
+        'title' => '',
+        'url' => '',
+        'weight' => 0,
+      ];
+    }
+    if (isset($parents[2]) && $parents[2] == 'delete') {
+      unset($items[$parents[1]]);
+    }
+
+    $form_state->setValue('interstitial', $items);
+    $form_state->setRebuild(TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Process intersticial breadcrumb items.
+    $interstitial_items = $form_state->getValue('interstitial');
+    $interstitial = [];
+    foreach ($interstitial_items as $item) {
+      $interstitial[] = [
+        'title' => $item['title'],
+        'url' => $item['url'],
+      ];
+    }
+
+    // Retrieve the configuration.
+    $this->configFactory->getEditable(static::SETTINGS)
+      // Set the submitted configuration setting.
+      ->set('site_root_breadcrumb_title', $form_state->getValue('site_root_breadcrumb_title'))
+      ->set('interstitial_breadcrumbs', $interstitial)
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -48,6 +48,17 @@ class SettingsForm extends ConfigFormBase {
       '#title' => $this->t('Site Root Breadcrumb Title'),
       '#description' => $this->t('The title used for this site in breadcrumbs. E.g. "Nebraska > [Site Root Breadcrumb Title] > [Page Title]". In the instance of the flagship site, this setting will be empty.'),
       '#default_value' => $config->get('site_root_breadcrumb_title'),
+      '#states' => [
+        'disabled' => [
+          ':input[name="site_root_breadcrumb_title_use_site_title"]' => ['checked' => TRUE],
+        ],
+      ],
+    ];
+    $form['site_root_breadcrumb_title_use_site_title'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Use Site Title as Site Root Breadcrumb Title'),
+      '#description' => $this->t('If checked, the Site Title will be used instead of a custom title.'),
+      '#default_value' => $config->get('site_root_breadcrumb_title_use_site_title'),
     ];
 
     $form['interstitial_wrapper'] = [
@@ -205,6 +216,7 @@ class SettingsForm extends ConfigFormBase {
     $this->configFactory->getEditable(static::SETTINGS)
       // Set the submitted configuration setting.
       ->set('site_root_breadcrumb_title', $form_state->getValue('site_root_breadcrumb_title'))
+      ->set('site_root_breadcrumb_title_use_site_title', $form_state->getValue('site_root_breadcrumb_title_use_site_title'))
       ->set('interstitial_breadcrumbs', $interstitial)
       ->save();
 

--- a/src/UnlBreadcrumbBuilder.php
+++ b/src/UnlBreadcrumbBuilder.php
@@ -224,7 +224,7 @@ class UnlBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
     array_pop($links);
 
     // Set site root breadcrumb.
-    if ($this->config->get('site_root_breadcrumb_title_use_site_title')) {
+    if ($this->config->get('site_root_breadcrumb_title_use_site_name')) {
       $links[] = Link::createFromRoute($this->siteConfig->get('name'), '<front>');
     }
     elseif ($site_root_breadcrumb_title = $this->config->get('site_root_breadcrumb_title')) {

--- a/src/UnlBreadcrumbBuilder.php
+++ b/src/UnlBreadcrumbBuilder.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace Drupal\unl_breadcrumbs;
+
+use Drupal\Core\Access\AccessManagerInterface;
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Controller\TitleResolverInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Menu\MenuActiveTrail;
+use Drupal\Core\Path\CurrentPathStack;
+use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
+use Drupal\Core\Routing\AdminContext;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Routing\RequestContext;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
+use Drupal\menu_link_content\Plugin\Menu\MenuLinkContent;
+use Drupal\system\PathBasedBreadcrumbBuilder;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
+
+/**
+ * A version of PathBasedBreadcrumbBuilder extended to meet UNL needs.
+ */
+class UnlBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
+
+  /**
+   * The router request context.
+   *
+   * @var \Drupal\Core\Routing\RequestContext
+   */
+  protected $context;
+
+  /**
+   * The menu link access service.
+   *
+   * @var \Drupal\Core\Access\AccessManagerInterface
+   */
+  protected $accessManager;
+
+  /**
+   * The dynamic router service.
+   *
+   * @var \Symfony\Component\Routing\Matcher\RequestMatcherInterface
+   */
+  protected $router;
+
+  /**
+   * The inbound path processor.
+   *
+   * @var \Drupal\Core\PathProcessor\InboundPathProcessorInterface
+   */
+  protected $pathProcessor;
+
+  /**
+   * The title resolver.
+   *
+   * @var \Drupal\Core\Controller\TitleResolverInterface
+   */
+  protected $titleResolver;
+
+  /**
+   * The current user object.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The current path service.
+   *
+   * @var \Drupal\Core\Path\CurrentPathStack
+   */
+  protected $currentPath;
+
+  /**
+   * The patch matcher service.
+   *
+   * @var \Drupal\Core\Path\PathMatcherInterface
+   */
+  protected $pathMatcher;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The request stack that controls the lifecycle of requests.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * A helper class to determine whether the route is an admin one.
+   *
+   * @var \Drupal\Core\Routing\AdminContext
+   */
+  protected $adminContext;
+
+  /**
+   * Provides the default implementation of the active menu trail service.
+   *
+   * @var \Drupal\Core\Menu\MenuActiveTrail
+   */
+  protected $menuActiveTrail;
+
+  /**
+   * The route match service.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $routeMatch;
+
+  /**
+   * The route match service.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * Constructs the UnlBreadcrumbBuilder.
+   *
+   * @param \Drupal\Core\Routing\RequestContext $context
+   *   The router request context.
+   * @param \Drupal\Core\Access\AccessManagerInterface $access_manager
+   *   The menu link access service.
+   * @param \Symfony\Component\Routing\Matcher\RequestMatcherInterface $router
+   *   The dynamic router service.
+   * @param \Drupal\Core\PathProcessor\InboundPathProcessorInterface $path_processor
+   *   The inbound path processor.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Core\Controller\TitleResolverInterface $title_resolver
+   *   The title resolver service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user object.
+   * @param \Drupal\Core\Path\CurrentPathStack $current_path
+   *   The current path.
+   * @param \Drupal\Core\Path\PathMatcherInterface $path_matcher
+   *   The path matcher service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack that controls the lifecycle of requests.
+   * @param \Drupal\Core\Routing\AdminContext $admin_context
+   *   A helper class to determine whether the route is an admin one.
+   * @param \Drupal\Core\Menu\MenuActiveTrail $menu_active_trail
+   *   Provides the default implementation of the active menu trail service.
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
+   *   The route match service.
+   */
+  public function __construct(RequestContext $context, AccessManagerInterface $access_manager, RequestMatcherInterface $router, InboundPathProcessorInterface $path_processor, ConfigFactoryInterface $config_factory, TitleResolverInterface $title_resolver, AccountInterface $current_user, CurrentPathStack $current_path, PathMatcherInterface $path_matcher = NULL, EntityTypeManagerInterface $entity_type_manager, RequestStack $request_stack, AdminContext $admin_context, MenuActiveTrail $menu_active_trail, CurrentRouteMatch $route_match) {
+    parent::__construct($context, $access_manager, $router, $path_processor, $config_factory, $title_resolver, $current_user, $current_path, $path_matcher);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->requestStack = $request_stack;
+    $this->adminContext = $admin_context;
+    $this->menuActiveTrail = $menu_active_trail;
+    $this->routeMatch = $route_match;
+    $this->config = $config_factory->get('unl_breadcrumbs.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    // Disable for admin routes.
+    if ($this->adminContext->isAdminRoute()) {
+      return FALSE;
+    }
+    else {
+      return TRUE;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    // Get breadcrumb array
+    // from \Drupal\system\PathBasedBreadcrumbBuilder::build().
+    $breadcrumbs = parent::build($route_match);
+
+    // If initial config has not been set, then simply return the breadcrumbs
+    // generated by \Drupal\system\PathBasedBreadcrumbBuilder::build().
+    if ($this->config->isNew()) {
+      return $breadcrumbs;
+    }
+
+    // Links can only be added to to breadcrumbs; Links cannot be modified or
+    // removed. Thus, we copy the links and cache data to add to a new
+    // breadcrumbs instance.
+    $links = $breadcrumbs->getLinks();
+    $cache_contexts = $breadcrumbs->getCacheContexts();
+    $cache_tags = $breadcrumbs->getCacheTags();
+    $cache_max_age = $breadcrumbs->getCacheMaxAge();
+
+    // Create new Breadcrumb instance.
+    $breadcrumbs = new Breadcrumb();
+    $breadcrumbs->addCacheContexts($cache_contexts);
+    $breadcrumbs->addCacheTags($cache_tags);
+    $breadcrumbs->mergeCacheMaxAge($cache_max_age);
+
+    // It's easier to insert interstitial items if the links array is reversed.
+    $links = array_reverse($links);
+    // Remove "Home" link.
+    array_pop($links);
+
+    // Set site root breadcrumb.
+    if ($site_root_breadcrumb_title = $this->config->get('site_root_breadcrumb_title')) {
+      $links[] = Link::createFromRoute($site_root_breadcrumb_title, '<front>');
+    }
+
+    // Add interstitial links.
+    $interstitial_items = $this->config->get('interstitial_breadcrumbs');
+    if (!empty($interstitial_items)) {
+      $interstitial_items = array_reverse($interstitial_items);
+      foreach ($interstitial_items as $item) {
+        $url = Url::fromUri($item['url']);
+        $links[] = new Link($item['title'], $url);
+      }
+    }
+    // Add expire cache context for config changes.
+    $breadcrumbs->addCacheableDependency($this->config);
+
+    // Set root item to the flagship site.
+    $url = Url::fromUri('https://www.unl.edu');
+    $links[] = new Link('Nebraska', $url);
+
+    $links = array_reverse($links);
+
+    // Add page title if user has access to page.
+    $access = $this->accessManager->check($route_match, $this->currentUser, NULL, TRUE);
+    // Merge the access result's cacheability metadata.
+    $breadcrumbs->addCacheableDependency($access);
+    if ($access->isAllowed()) {
+      // Add title for current page as final, unlinked breadcrumb.
+      // If menu link exists, use menu link title.
+      $active_link = $this->menuActiveTrail->getActiveLink();
+
+      if ($active_link instanceof MenuLinkContent) {
+        $title = $active_link->getTitle();
+
+        // Add cacheable dependency for menu item.
+        // This was shamelessly "borrowed" from the menu_breadcrumb module.
+        $uuid = $active_link->getDerivativeId();
+        $entities = $this->entityTypeManager->getStorage('menu_link_content')->loadByProperties(['uuid' => $uuid]);
+        if ($entity = reset($entities)) {
+          $breadcrumbs->addCacheableDependency($entity);
+        }
+      }
+      // If no menu link, then get title from title resolver.
+      else {
+        $request = $this->requestStack->getCurrentRequest();
+        $title = $this->titleResolver->getTitle($request, $route_match->getRouteObject());
+      }
+      if (!empty($title)) {
+        $links[] = Link::createFromRoute($title, '<none>');
+      }
+    }
+
+    // If page belongs to an entity, then add it as a cacheable dependency.
+    if ($entity = $this->getPageEntity()) {
+      $breadcrumbs->addCacheableDependency($entity);
+    }
+
+    return $breadcrumbs->setLinks($links);
+  }
+
+  /**
+   * Attempts to return entity object for the current route.
+   *
+   * Code is from https://www.drupal.org/forum/support/module-development-and-code-questions/2014-07-25/drupal-8-get-entity-object-given#comment-12752478
+   *
+   * @return mixed
+   *   entity object if one exists; otherwise, NULL
+   */
+  protected function getPageEntity() {
+    $page_entity = &drupal_static(__FUNCTION__, NULL);
+    if (isset($page_entity)) {
+      return $page_entity ?: NULL;
+    }
+    foreach ($this->routeMatch->getParameters() as $param) {
+      if ($param instanceof EntityInterface) {
+        $page_entity = $param;
+        break;
+      }
+    }
+    if (!isset($page_entity)) {
+      // Some routes don't properly define entity parameters.
+      // Thus, try to load them by its raw Id, if given.
+      $types = $this->entityTypeManager->getDefinitions();
+      foreach ($this->routeMatch->getParameters()->keys() as $param_key) {
+        if (!isset($types[$param_key])) {
+          continue;
+        }
+        if ($param = $this->routeMatch->getParameter($param_key)) {
+          if (is_string($param) || is_numeric($param)) {
+            try {
+              $page_entity = $this->entityTypeManager->getStorage($param_key)->load($param);
+            }
+            catch (\Exception $e) {
+            }
+          }
+          break;
+        }
+      }
+    }
+    if (!isset($page_entity) || !$page_entity->access('view')) {
+      $page_entity = FALSE;
+      return NULL;
+    }
+    return $page_entity;
+  }
+
+}

--- a/src/UnlBreadcrumbBuilder.php
+++ b/src/UnlBreadcrumbBuilder.php
@@ -121,11 +121,18 @@ class UnlBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
   protected $routeMatch;
 
   /**
-   * The route match service.
+   * UNL Breadcrumbs config (unl_breadcrumbs.settings).
    *
    * @var \Drupal\Core\Config\Config
    */
   protected $config;
+
+  /**
+   * Site config (system.site)
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $siteConfig;
 
   /**
    * Constructs the UnlBreadcrumbBuilder.
@@ -167,6 +174,7 @@ class UnlBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
     $this->menuActiveTrail = $menu_active_trail;
     $this->routeMatch = $route_match;
     $this->config = $config_factory->get('unl_breadcrumbs.settings');
+    $this->siteConfig = $config_factory->get('system.site');
   }
 
   /**
@@ -216,7 +224,10 @@ class UnlBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
     array_pop($links);
 
     // Set site root breadcrumb.
-    if ($site_root_breadcrumb_title = $this->config->get('site_root_breadcrumb_title')) {
+    if ($this->config->get('site_root_breadcrumb_title_use_site_title')) {
+      $links[] = Link::createFromRoute($this->siteConfig->get('name'), '<front>');
+    }
+    elseif ($site_root_breadcrumb_title = $this->config->get('site_root_breadcrumb_title')) {
       $links[] = Link::createFromRoute($site_root_breadcrumb_title, '<front>');
     }
 

--- a/unl_breadcrumbs.info.yml
+++ b/unl_breadcrumbs.info.yml
@@ -1,0 +1,8 @@
+name: 'UNL Breadcrumbs'
+description: 'Breadcrumb customization options'
+package: UNL
+
+type: module
+core: 8.x
+
+version: 1.x

--- a/unl_breadcrumbs.links.menu.yml
+++ b/unl_breadcrumbs.links.menu.yml
@@ -1,0 +1,5 @@
+unl_breadcrumbs.settings:
+  title: UNL Breadcrumbs
+  description: 'Configure UNL Breadcrumbs settings'
+  route_name: unl_breadcrumbs.config
+  parent: system.admin_config_ui

--- a/unl_breadcrumbs.permissions.yml
+++ b/unl_breadcrumbs.permissions.yml
@@ -1,0 +1,3 @@
+administer unl breadcrumbs:
+  title: 'Administer UNL Breadcrumbs'
+  description: 'Allows a user to configure UNL Breadcrumbs settings.'

--- a/unl_breadcrumbs.routing.yml
+++ b/unl_breadcrumbs.routing.yml
@@ -1,0 +1,7 @@
+unl_breadcrumbs.config:
+  path: /admin/config/user-interface/unl-breadcrumbs
+  defaults:
+    _title: 'UNL Breadcrumbs'
+    _form: '\Drupal\unl_breadcrumbs\Form\SettingsForm'
+  requirements:
+    _permission: 'administer unl breadcrumbs'

--- a/unl_breadcrumbs.services.yml
+++ b/unl_breadcrumbs.services.yml
@@ -1,0 +1,6 @@
+services:
+  unl_breadcrumbs.breadcrumb:
+    class: Drupal\unl_breadcrumbs\UnlBreadcrumbBuilder
+    arguments: ['@router.request_context', '@access_manager', '@router', '@path_processor_manager', '@config.factory',  '@title_resolver', '@current_user', '@path.current', '@path.matcher', '@entity_type.manager', '@request_stack', '@router.admin_context', '@menu.active_trail', '@current_route_match']
+    tags:
+      - { name: breadcrumb_builder, priority: 1003 }


### PR DESCRIPTION
This project was originally created for use with UNL-CMS-2, which has been deprecated in favor of Project Herbie. This issue proposes repurposing the `unl_breadcrumbs` namespace for a custom module for Project Herbie.

Current code exists in `master` branch. New code will go in `8.x-1.x`.